### PR TITLE
Set severity warning to some rules

### DIFF
--- a/lib/textlint-rule-preset-ameba.js
+++ b/lib/textlint-rule-preset-ameba.js
@@ -79,15 +79,35 @@ module.exports = {
       max: 3
     },
     'no-synonyms': true,
-    'no-insert-dropping-sa': true,
-    'prefer-tari-tari': true,
-    'ja-no-mixed-period': true,
-    'no-dropping-the-ra': true,
-    'ja-no-abusage': true,
-    'no-doubled-joshi': true,
-    'no-mix-dearu-desumasu': true,
-    'ja-no-redundant-expression': true,
-    'no-insert-re': true,
-    'no-dropping-i': true
+    'no-insert-dropping-sa': {
+      severity: 'warning'
+    },
+    'prefer-tari-tari': {
+      severity: 'warning'
+    },
+    'ja-no-mixed-period': {
+      severity: 'warning'
+    },
+    'no-dropping-the-ra': {
+      severity: 'warning'
+    },
+    'ja-no-abusage': {
+      severity: 'warning'
+    },
+    'no-doubled-joshi': {
+      severity: 'warning'
+    },
+    'no-mix-dearu-desumasu': {
+      severity: 'warning'
+    },
+    'ja-no-redundant-expression': {
+      severity: 'warning'
+    },
+    'no-insert-re': {
+      severity: 'warning'
+    },
+    'no-dropping-i': {
+      severity: 'warning'
+    }
   }
 };


### PR DESCRIPTION
「必ず直したいルール」「できれば直したいルール」の分類を[Severity config](https://github.com/textlint/textlint/blob/master/docs/configuring.md#severity-config-of-rules)で指定してみました。なお、各ルールの指定は[プリセットルールの精査 ](https://github.com/openameba/textlint-rule-preset-ameba/issues/1)の過程で変更される予定です。


- 必ず直したいルール: error (default)
- できれば直したいルール: warning

ref #1