### PR TITLE
Improve prh rules about Ameba

### DIFF
--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -2,13 +2,15 @@ version: 1
 
 rules:
   - expected: アメーバID
-    pattern:  /amebaid/i
+    pattern:  /ameba\s?id/i
     specs:
       - from: amebaid
         to: アメーバID
       - from: AMEBAID
         to: アメーバID
-    
+      - from: Ameba ID
+        to: アメーバID
+
   - expected: Ameba
     pattern: /アメーバ(id)?/i
     regexpMustEmpty: $1

--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -8,19 +8,27 @@ rules:
         to: アメーバID
       - from: AMEBAID
         to: アメーバID
-
-  - expected: Amebaブログ
-    patterns:
-      - あめーばぶろぐ
-      - アメーバブログ
-      - アメーバblog
+    
+  - expected: Ameba
+    pattern: /アメーバ(id)?/i
+    regexpMustEmpty: $1
     specs:
-      - from: あめーばぶろぐ
-        to: Amebaブログ
+      - from: アメーバ
+        to: Ameba
+      - from: アメーバID
+        to: アメーバID
       - from: アメーバブログ
         to: Amebaブログ
-      - from: アメーバblog
-        to: Amebaブログ
+      - from: アメーバニュース
+        to: Amebaニュース
+      - from: アメーバアプリ
+        to: Amebaアプリ
+
+  - expected: Ameba
+    pattern: あめーば
+    specs:
+      - from: あめーば
+        to: Ameba
   
   - expected: アメブロ
     pattern: /ameblo/i
@@ -44,10 +52,13 @@ rules:
         to: 芸能人・有名人ブログ
   
   - expected: 公式トップブロガー
-    pattern: トップブロガー
+    pattern:  /(公式)?トップブロガー/
+    regexpMustEmpty: $1
     specs:
       - from: トップブロガー
         to: 公式トップブロガー
+      - from: Ameba公式トップブロガー
+        to: Ameba公式トップブロガー
 
   - expected: ABEMA
     patterns:

--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -2,13 +2,17 @@ version: 1
 
 rules:
   - expected: アメーバID
-    pattern:  /ameba\s?id/i
+    pattern:  /(ameba|アメーバ|あめーば)\s?id/i
     specs:
       - from: amebaid
         to: アメーバID
       - from: AMEBAID
         to: アメーバID
       - from: Ameba ID
+        to: アメーバID
+      - from: アメーバ ID
+        to: アメーバID
+      - from: あめーば ID
         to: アメーバID
 
   - expected: Ameba


### PR DESCRIPTION
以下の表記ゆれルールを改善しました。

- 「アメーバID」の時以外の「アメーバ」「あめーば」は「Ameba」に変換する
- 「Ameba公式トップブロガー」など、「トップブロガー」の前に「公式」が予め存在する場合には、「公式」を付与しない
- 「Ameba ID」「アメーバ ID」「あめーば ID」のように間にスペースがある場合も「アメーバID」に変換する


