### PR TITLE
chore: add workflows on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - publish
+      - publish/dry-run
+
+jobs:
+  version:
+    name: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - name: Log in to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm whoami
+      - name: Dry run
+        run: npm publish --dry-run
+        if: github.ref == 'refs/heads/publish/dry-run'
+      - name: Publish
+        run: npm publish
+        if: github.ref == 'refs/heads/publish'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,41 @@
+name: versioning
+
+on:
+  push:
+    branches:
+      - version/major
+      - version/minor
+      - version/patch
+      - version/premajor
+      - version/preminor
+      - version/prepatch
+      - version/prerelease
+
+jobs:
+  version:
+    name: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - name: Set git user
+        run: |
+          git config --global user.email "<>"
+          git config --global user.name "openameba"
+      - name: Extract branch from git ref
+        run: |
+          echo "::set-output name=name::${GITHUB_REF#refs/*/}"
+          echo "::set-output name=version::${GITHUB_REF##*/}"
+        id: extract_branch
+      - run: npm version ${{ steps.extract_branch.outputs.version }}
+      - run: git push --tags
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          delete-branch: true
+          commit-message: 'chore: update version'
+          title: 'chore: update version'
+          body: ''


### PR DESCRIPTION
release(publish)に関するワークフローを追加しました。

- `version/*`: npm versionを実行し、tag作成・package.json更新、新規Pull Requestを作成します
- `publish/dry-run`: npm publish --dry-runをします (後でどっかのフローに入れ込むかも)
- `publish`: npm publishします

パッケージの規模的にちょうどいいので、CHANGELOGはお試しで、GitHubのAuto-generate release notesを使ってみます。
<img width="953" alt="Screen Shot 2021-10-20 at 2 49 47 PM" src="https://user-images.githubusercontent.com/869023/138035561-a289a6cb-4caf-4929-b0d8-72669fb9e915.png">

