### PR TITLE
chore: run workflow manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,16 @@
 name: publish
 
 on:
-  push:
-    branches:
-      - publish
-      - publish/dry-run
+  workflow_dispatch:
+    inputs:
+      opts:
+        description: 'input empty string if you want to publish, otherwise run with --dry-run'
+        required: false
+        default: '--dry-run'
 
 jobs:
-  version:
-    name: version
+  publish:
+    name: publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,9 +21,5 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm whoami
-      - name: Dry run
-        run: npm publish --dry-run
-        if: github.ref == 'refs/heads/publish/dry-run'
       - name: Publish
-        run: npm publish
-        if: github.ref == 'refs/heads/publish'
+        run: npm publish ${{ github.event.inputs.opts }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,15 +1,12 @@
 name: versioning
 
 on:
-  push:
-    branches:
-      - version/major
-      - version/minor
-      - version/patch
-      - version/premajor
-      - version/preminor
-      - version/prepatch
-      - version/prerelease
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'should be a valid semver string to semver.inc (one of patch, minor, major, prepatch, preminor, premajor, prerelease).'
+        required: true
+        default: 'minor'
 
 jobs:
   version:
@@ -24,12 +21,7 @@ jobs:
         run: |
           git config --global user.email "<>"
           git config --global user.name "openameba"
-      - name: Extract branch from git ref
-        run: |
-          echo "::set-output name=name::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=version::${GITHUB_REF##*/}"
-        id: extract_branch
-      - run: npm version ${{ steps.extract_branch.outputs.version }}
+      - run: npm version ${{ github.event.inputs.version }}
       - run: git push --tags
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
#23 でリリースに関連するワークフローを追加しましたが、それぞれworkflow_dispatchに変更しました。わかりやすく、ブランチプッシュによる意図しないPR作成もなくなると思われます。
