### PR TITLE
textlintのアメブロをAmebaブログに修正

### DIFF
--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -35,13 +35,11 @@ rules:
         to: Ameba
 
   - expected: Amebaブログ
-    pattern: /(ameblo|アメブロ)/i
+    pattern: /ameblo/i
     specs:
       - from: ameblo
         to: Amebaブログ
       - from: AMEBLO
-        to: Amebaブログ
-      - from: アメブロ
         to: Amebaブログ
 
   - expected: 芸能人・有名人ブログ

--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -34,13 +34,15 @@ rules:
       - from: あめーば
         to: Ameba
 
-  - expected: アメブロ
-    pattern: /ameblo/i
+  - expected: Amebaブログ
+    pattern: /(ameblo|アメブロ)/i
     specs:
       - from: ameblo
-        to: アメブロ
+        to: Amebaブログ
       - from: AMEBLO
-        to: アメブロ
+        to: Amebaブログ
+      - from: アメブロ
+        to: Amebaブログ
 
   - expected: 芸能人・有名人ブログ
     patterns:


### PR DESCRIPTION
### 概要
今まで「AMEBLO」に対してチェックをおこなっていましたが、
そもそもアメブロはできるだけ無くしていき「Amebaブログ」にしていきたいというのがあり修正してみました。

- ameblo: 「Amebaブログ」に修正
- アメブロ: 呼称として利用できるためlintではチェックしません。ただしできる限り「Amebaブログ」を使ってください

### レビュー希望日
急ぎのものではないのでおてすきで大丈夫です。