### PR TITLE
textlintのルールにAmebaLIFEを追加

### DIFF
--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -42,6 +42,25 @@ rules:
       - from: AMEBLO
         to: Amebaブログ
 
+  - expected: AmebaLIFE
+    pattern:
+      - AmebaLife
+      - Ameba Life
+      - Ameba life
+      - Amebaライフ
+      - Ameba ライフ
+    specs:
+      - from: AmebaLife
+        to: AmebaLIFE
+      - from: Ameba Life
+        to: AmebaLIFE
+      - from: Ameba life
+        to: AmebaLIFE
+      - from: Amebaライフ
+        to: AmebaLIFE
+      - from: Ameba ライフ
+        to: AmebaLIFE
+
   - expected: 芸能人・有名人ブログ
     patterns:
       - オフィシャルブログ


### PR DESCRIPTION
### 概要
小文字になりがちな「AmebaLife」と周年に該当する「XXth」のルールを追加してみました。
周年の数字部分は2桁の数字。というルールに留めています。

### 悩んでいるところ
「つくる、つむぐ、つづく、」の最後にあたる「、」をチェックにいれてもいいかなと思ったのですがそもそも文章として「、」が3回以上連続したらだめだよルールに引っかかってしまってダメでした。
この単語だけルールから除外してチェックする。みたいなことができればいいのかもしれないですがドキュメント読んでもいまいちいい解決方法見当たらずー。