### PR TITLE
Ameba LIFEに関するテキストのルールを修正

### DIFF
--- a/lib/prh-service.yml
+++ b/lib/prh-service.yml
@@ -42,24 +42,27 @@ rules:
       - from: AMEBLO
         to: Amebaブログ
 
-  - expected: AmebaLIFE
+  - expected: Ameba LIFE
     pattern:
+      - AmebaLIFE
       - AmebaLife
       - Ameba Life
       - Ameba life
       - Amebaライフ
       - Ameba ライフ
     specs:
+      - from: AmebaLIFE
+        to: Ameba LIFE
       - from: AmebaLife
-        to: AmebaLIFE
+        to: Ameba LIFE
       - from: Ameba Life
-        to: AmebaLIFE
+        to: Ameba LIFE
       - from: Ameba life
-        to: AmebaLIFE
+        to: Ameba LIFE
       - from: Amebaライフ
-        to: AmebaLIFE
+        to: Ameba LIFE
       - from: Ameba ライフ
-        to: AmebaLIFE
+        to: Ameba LIFE
 
   - expected: 芸能人・有名人ブログ
     patterns:


### PR DESCRIPTION
### 概要

![image](https://github.com/openameba/textlint-rule-preset-ameba/assets/80251820/120893b9-8f35-4c31-84ec-7fcdf071dc8d)

そもそもなのですがAmeba LIFEは半角スペースありが正しかったみたいなので修正しました。
「事業本部」はサービス用語ではないかなと思って追加していませんがご意見募集中です。