### PR TITLE
ci: actions/cacheをv4に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: '14'
       - id: npm-cache
         run: echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '14'
       - id: npm-cache
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ steps.npm-cache.outputs.dir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
       - id: npm-cache


### PR DESCRIPTION
概要
actions/cache@v3の廃止に伴い、1月末までにv4への更新が必要です

ついでに古いset-output記法が同ワークフローファイルにあったので修正しました

ついでにactions/setup-nodeがbeta版だったので修正しました

関連リンク
https://www.notion.so/cyberagent-group/openameba-textlint-rule-preset-ameba-165b68753fe9807c82c4dc44b8f50fbf
https://github.com/actions/toolkit/discussions/1890

確認項目
testワークフローが正常終了していればOKです
(set-output記法の警告が消えます)

その他
1月中にマージ