### PR TITLE
ci: update action to create PR

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,9 @@
 name: versioning
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -26,8 +30,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          delete-branch: true
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'chore: update version'
+          branch: chore/update-version
+          delete-branch: true
           title: 'chore: update version'
           body: ''

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
       - name: Set git user


### PR DESCRIPTION
[コケた](https://github.com/openameba/textlint-rule-preset-ameba/actions/runs/17542824585)ため更新しました。

PR作成のところはSpindleに合わせています。

https://github.com/openameba/spindle/blob/135e77c43645f986f8c5d323b502deffd5718026/.github/workflows/build-icon-from-figma.yml#L53-L65


This pull request updates the `.github/workflows/version.yml` workflow to improve security, maintainability, and automation consistency. The most significant changes involve updating action versions, refining permissions, and standardizing pull request creation.

**Workflow configuration updates:**

* Added explicit `permissions` for `contents: write` and `pull-requests: write` to ensure the workflow has the necessary access for versioning operations.

**Action version upgrades:**

* Updated `actions/setup-node` to the latest stable version (`v4.4.0`) for improved reliability and support.

**Pull request automation improvements:**

* Standardized the author and committer to `github-actions[bot]`, set a consistent branch name (`chore/update-version`), and retained the `delete-branch` option for cleaner repository management.