### PR TITLE
chore: add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@openameba/textlint-rule-preset-ameba",
   "version": "0.5.2-0",
   "description": "textlint rule preset for Ameba",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openameba/textlint-rule-preset-ameba"
+  },
   "main": "lib/textlint-rule-preset-ameba.js",
   "scripts": {
     "test": "run-p lint:* format",


### PR DESCRIPTION
リリースにあたり、package.jsonにリポジトリ情報の記述が必要でした。

失敗: https://github.com/openameba/textlint-rule-preset-ameba/actions/runs/17545237950
成功: https://github.com/openameba/textlint-rule-preset-ameba/actions/runs/17545325876

こりでsecrets全消しできるのでヤッピーでこざいます。

